### PR TITLE
Show all date on reg form.

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "develop:live": "netlify dev --live",
     "test": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:snapshot": "yarn percy snapshot public/*"
+    "test:snapshot": "yarn percy snapshot public/"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "develop:live": "netlify dev --live",
     "test": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:snapshot": "yarn percy snapshot public/"
+    "test:snapshot": "yarn percy snapshot public/*"
   }
 }

--- a/src/components/form/components/DateTimeField.test.tsx
+++ b/src/components/form/components/DateTimeField.test.tsx
@@ -16,7 +16,7 @@ describe('<TimeField>', () => {
   })
 
   it('passes time back to onChange event', () => {
-    const mount = render(<TimeField {...props} value={new Date('2021-08-21 06:01 EDT')} onChange={onChangeSpy} />)
+    const mount = render(<TimeField {...props} value={new Date('2021-08-21 06:01 EDT')} onChange={onChangeSpy} help={'Select the date'} />)
 
     expect(mount.getByLabelText(/time/i)).toHaveProperty('value', '06:00')
     fireEvent.change(mount.getByLabelText(/time/i), {

--- a/src/components/registration/components/select-brevets.tsx
+++ b/src/components/registration/components/select-brevets.tsx
@@ -22,7 +22,7 @@ type Props = {
 }
 
 export const SelectBrevets = ({ onChange }: Props) => {
-    const { brevets } = useEvents({})
+    const { brevets } = useEvents({limit: false})
     const { allowedToRegister, getBrevetRegistrationDeadline } = useAllowedStartTimes()
     const [selectedBrevetId, setSelectedBrevetId] = useState<Brevet['id']>('')
     const [filters, setFilters] = useState({

--- a/src/data/events/useEvents.test.ts
+++ b/src/data/events/useEvents.test.ts
@@ -4,34 +4,37 @@ import { useEvents } from './useEvents'
 jest.mock('gatsby', () => ({
   __esModule: true,
   graphql: jest.fn(),
-  useStaticQuery: jest.fn().mockReturnValue({allEvent: { nodes: [
-    {
-      chapter: 'Toronto',
-      distance: 200,
-      event: 'brevet',
-      id: 1,
-      route: 'Waterfront East',
-      rwgpsUrl: 'https://ridewithgps.com/routes/20784084',
-      startLocation: 'Rouge GO',
-      date: 'September 7 2021 08:00 EDT'
-    },
-    {
-      chapter: 'Huron',
-      distance: 200,
-      event: 'brevet',
-      id: 1,
-      route: 'Waterfront East',
-      rwgpsUrl: 'https://ridewithgps.com/routes/20784084',
-      startLocation: 'Rouge GO',
-      date: 'August 1 2021 08:00 EDT'
-    }]
-  }})
+  useStaticQuery: jest.fn().mockReturnValue({
+    allEvent: {
+      nodes: [
+        {
+          chapter: 'Toronto',
+          distance: 200,
+          event: 'brevet',
+          id: 1,
+          route: 'Waterfront East',
+          rwgpsUrl: 'https://ridewithgps.com/routes/20784084',
+          startLocation: 'Rouge GO',
+          date: 'September 7 2021 08:00 EDT'
+        },
+        {
+          chapter: 'Huron',
+          distance: 200,
+          event: 'brevet',
+          id: 1,
+          route: 'Waterfront East',
+          rwgpsUrl: 'https://ridewithgps.com/routes/20784084',
+          startLocation: 'Rouge GO',
+          date: 'August 1 2021 08:00 EDT'
+        }]
+    }
+  })
 }))
 
 describe('useEvents()', () => {
   it('filters by date', () => {
     const after = new Date('August 30 2021')
-    const { result: {current}  } = renderHook(() => useEvents({after}))
+    const { result: { current } } = renderHook(() => useEvents({ after }))
 
     current.brevets.forEach((brevet) => {
       expect(brevet.date.valueOf()).toBeGreaterThan(after.valueOf())
@@ -40,7 +43,7 @@ describe('useEvents()', () => {
 
   it('sorts by date', () => {
     const after = new Date('Jan 1 2019')
-    const { result } = renderHook(() => useEvents({after}))
+    const { result } = renderHook(() => useEvents({ after }))
 
     expect(result.current.brevets[0].date.valueOf())
       .toBeLessThan(result.current.brevets[1].date.valueOf())
@@ -48,7 +51,7 @@ describe('useEvents()', () => {
 
   it('filters by chapter', () => {
     const chapter = 'Toronto'
-    const { result } = renderHook(() => useEvents({chapter}))
+    const { result } = renderHook(() => useEvents({ chapter }))
 
     result.current.brevets.forEach((brevet) => {
       expect(brevet.chapter).toEqual(chapter)
@@ -57,8 +60,14 @@ describe('useEvents()', () => {
 
   it('slices by limit', () => {
     const limit = 1
-    const { result } = renderHook(() => useEvents({limit}))
+    const { result } = renderHook(() => useEvents({ limit }))
 
     expect(result.current.brevets).toHaveLength(limit)
+  })
+
+  it('returns all if no limit', () => {
+    const { result } = renderHook(() => useEvents({ limit: false }))
+
+    expect(result.current.brevets).toHaveLength(2)
   })
 })

--- a/src/data/events/useEvents.ts
+++ b/src/data/events/useEvents.ts
@@ -41,7 +41,7 @@ query {
 type UseEventFilters = {
   chapter?: Event['chapter'],
   after?: Date,
-  limit?: number
+  limit?: number | boolean,
 }
 
 const sortEventAsc = (a: Event, b: Event) => (a.date < b.date ? -1 : 1)
@@ -52,13 +52,13 @@ export const useEvents = ({ chapter, after = new Date(Date.now()), limit = 20 }:
   } = useStaticQuery(brevetQuery)
 
   const filteredEvents: Event[] = useMemo(() => events.map((event: Event) => ({
-      ...event,
-      date: new Date(event.date)
-    })).sort(sortEventAsc).filter((event: Event) => {
-      const matchDate = new Date(event.date) > after
-      const matchChapter = chapter ? event.chapter === chapter : true
-      return matchDate && matchChapter
-  }).slice(0, limit), [chapter, after, limit])
+    ...event,
+    date: new Date(event.date)
+  })).sort(sortEventAsc).filter((event: Event) => {
+    const matchDate = new Date(event.date) > after
+    const matchChapter = chapter ? event.chapter === chapter : true
+    return matchDate && matchChapter
+  }).slice(0, limit || undefined), [chapter, after, limit])
 
   return {
     loading: false,


### PR DESCRIPTION
stacktrace for dep warning:

```
➜ randonneurs-to (fix/regform) ✗ node --trace-deprecation node_modules/gatsby/dist/bin/gatsby build
success open and validate gatsby-configs, load plugins - 3.491s

 ERROR 

(node:81502) [DEP0148] DeprecationWarning: Use of deprecated folder
mapping "./public/" in the "exports" field module resolution of the
package at /Users/erinmarchak/Sites/github/emarchak/randonneurs-to/node_mo
dules/extract-files/package.json.
Update this package.json to use a subpath pattern like "./public/*".
    at emitFolderMapDeprecation (node:internal/modules/esm/resolve:99:11)
    at packageExportsResolve (node:internal/modules/esm/resolve:688:7)
    at resolveExports (node:internal/modules/cjs/loader:482:36)
    at Function.Module._findPath (node:internal/modules/cjs/loader:522:31)
    at Function.Module._resolveFilename
(node:internal/modules/cjs/loader:919:27)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (/Users/erinmarchak/Sites/github/emarchak/randonneurs-to/no
de_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at Object.<anonymous>
(/Users/erinmarchak/Sites/github/emarchak/randonneurs-to/node_modules/apol
lo-upload-client/public/createUploadLink.js:18:20)
    at Module._compile (/Users/erinmarchak/Sites/github/emarchak/randonneu
rs-to/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js
(node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (/Users/erinmarchak/Sites/github/emarchak/randonneurs-to/no
de_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at Object.<anonymous> (/Users/erinmarchak/Sites/github/emarchak/randon
neurs-to/node_modules/apollo-upload-client/public/index.js:3:28)

success onPreInit - 0.054s
success initialize cache - 0.335s
success copy gatsby files - 0.336s
success Compiling Gatsby Functions - 0.713s
success onPreBootstrap - 0.734s
success createSchemaCustomization - 0.018s
gatsby-source-ccn result Created 134 riders
warn Calling `addThirdPartySchema` in the `sourceNodes` API is deprecated.
 Please use: `createSchemaCustomization`.
success Checking for changed pages - 0.001s
success source and transform nodes - 6.345s
success building schema - 2.117s
success createPages - 0.086s
success createPagesStatefully - 0.969s
info Total nodes: 1247, SitePage nodes: 31 (use --verbose for breakdown)
success Checking for changed pages - 0.002s
success Cleaning up stale page-data - 0.013s
success update schema - 0.145s
success onPreExtractQueries - 0.001s
success extract queries from components - 2.016s
success write out redirect data - 0.002s
success onPostBootstrap - 0.006s
info bootstrap finished - 20.308s
success run static queries - 1.019s - 3/3 2.94/s
success write out requires - 0.007s
success Building production JavaScript and CSS bundles - 2.419s
success Rewriting compilation hashes - 0.424s
success Writing page-data.json files to public directory - 0.007s - 0/0
0.00/s
success Caching JavaScript and CSS webpack compilation - 0.853s
success Building HTML renderer - 1.127s
success Caching HTML renderer compilation - 0.707s
success Building static HTML for pages - 1.350s - 31/31 22.97/s
success onPostBuild - 0.001s
info Done building in 27.286148563 sec

➜ randonneurs-to (fix/regform) ✗ q
➜ randonneurs-to (fix/regform) ✗ yarn why apollo-upload-client       
yarn why v1.22.10
[1/4] 🤔  Why do we have the module "apollo-upload-client"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "apollo-upload-client@14.1.3"
info Reasons this module exists
   - "gatsby-source-graphql#@graphql-tools#links" depends on it
   - Hoisted from "gatsby-source-graphql#@graphql-tools#links#apollo-upload-client"
info Disk size without dependencies: "76KB"
info Disk size with unique dependencies: "6.46MB"
info Disk size with transitive dependencies: "8.18MB"
info Number of shared dependencies: 16
✨  Done in 0.96s.
```